### PR TITLE
Enhance SereneAI site with CTA and privacy page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,19 @@
     <meta property="og:image" content="https://sereneai.co.uk/og-cover.jpg"> <meta name="twitter:card" content="summary_large_image">
 
     <link rel="canonical" href="https://sereneai.co.uk/">
+    <meta name="robots" content="index, follow">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "SereneAI LTD",
+      "url": "https://sereneai.co.uk/",
+      "address": {
+        "@type": "PostalAddress",
+        "addressCountry": "GB"
+      }
+    }
+    </script>
     <link rel="icon" href="/favicon.ico" sizes="any">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -247,6 +260,23 @@
         text-align:left;
         margin-top: 1rem; /* Added margin */
     }
+    .primary-cta{
+        display:inline-block;
+        background:var(--teal);
+        color:var(--white);
+        padding:1rem 2.5rem;
+        border-radius:30px;
+        font-family:'Montserrat',sans-serif;
+        font-weight:600;
+        font-size:1.2rem;
+        transition:background .3s, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+        margin-top:2rem;
+    }
+    .primary-cta:hover{
+        background:#16725D;
+        transform: translateY(-2px);
+        box-shadow:0 4px 8px rgba(22, 114, 93, 0.5);
+    }
     button{
         background:var(--teal);
         color:var(--white);
@@ -359,16 +389,17 @@
         <label for="nav-toggle" class="nav-label"><span></span></label>
 
         <nav aria-label="Main navigation">
-            <a href="#about">About</a>
-            <a href="#services">Services</a>
-            <a href="#contact">Contact</a>
+            <a href="#about" aria-label="About section">About</a>
+            <a href="#services" aria-label="Services section">Services</a>
+            <a href="#contact" aria-label="Contact section">Contact</a>
         </nav>
     </header>
 
     <main id="main-content">
         <section class="hero">
-            <h1>Clarity in an Automated World</h1>
-            <p>Helping businesses and creators navigate AI with confidence, integrity, and simplicity.</p>
+            <h1>AI Clarity for UK Businesses</h1>
+            <p>SereneAI helps UK SMEs unlock the benefits of automation and AI with tailored guidance.</p>
+            <a class="primary-cta" href="#contact">Book a Free AI Audit</a>
         </section>
 
         <section id="about" class="section">
@@ -398,6 +429,16 @@
             </div>
         </section>
 
+        <section id="testimonials" class="section">
+            <h2>What Our Clients Say</h2>
+            <p class="section-intro">Real stories from the businesses we’ve helped – coming soon.</p>
+            <div class="icons-row">
+                <div class="icon-card" aria-hidden="true" style="opacity:0.5;">&nbsp;</div>
+                <div class="icon-card" aria-hidden="true" style="opacity:0.5;">&nbsp;</div>
+                <div class="icon-card" aria-hidden="true" style="opacity:0.5;">&nbsp;</div>
+            </div>
+        </section>
+
         <section id="contact" class="contact-section">
             <h2>Contact Us</h2>
             <p class="section-intro">If you're ready to make AI work for you, let's connect. Fill out the form below to start a conversation.</p>
@@ -408,17 +449,17 @@
 
                 <div class="form-group">
                     <label for="name">Your Name</label>
-                    <input type="text" id="name" name="name" placeholder="Jane Doe" required />
+                    <input type="text" id="name" name="name" placeholder="Jane Doe" aria-label="Your Name" required />
                     <div class="error-msg" id="err-name" aria-live="assertive"></div>
                 </div>
                 <div class="form-group">
                     <label for="contact">Your Contact (Email or Phone)</label>
-                    <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" required />
+                    <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" aria-label="Your Contact" required />
                     <div class="error-msg" id="err-contact" aria-live="assertive"></div>
                 </div>
                 <div class="form-group">
                     <label for="question">Your Question</label>
-                    <textarea id="question" name="question" placeholder="What would you like to know?" required></textarea>
+                    <textarea id="question" name="question" placeholder="What would you like to know?" aria-label="Your Question" required></textarea>
                     <div class="error-msg" id="err-question" aria-live="assertive"></div>
                 </div>
                 <div class="cta"><button type="submit">Submit</button></div>
@@ -427,12 +468,12 @@
     </main>
 
     <footer role="contentinfo">
-        <p>&copy; <span id="current-year">2025</span> SereneAI LTD. All rights reserved.</p>
+        <p>&copy; <span id="current-year">2025</span> SereneAI LTD. All rights reserved. <a href="privacy.html">Privacy Policy</a></p>
     </footer>
 
     <div id="cookie-banner">
         <p>
-            This website uses cookies to enhance your experience. By continuing to browse, you consent to our use of cookies as described in our <a href="your-privacy-policy-url" style="color:#1D8A73; text-decoration:underline;">Privacy Policy</a>.
+            This website uses cookies to enhance your experience. By continuing to browse, you consent to our use of cookies as described in our <a href="privacy.html" style="color:#1D8A73; text-decoration:underline;">Privacy Policy</a>.
         </p>
         <button id="accept-cookies">Accept</button>
     </div>
@@ -494,17 +535,17 @@
                                 <input type="text" name="_gotcha" style="display:none">
                                 <div class="form-group">
                                     <label for="name">Your Name</label>
-                                    <input type="text" id="name" name="name" placeholder="Jane Doe" required />
-                                    <div class="error-msg" id="err-name" aria-live="assertive"></div>
+                                    <input type="text" id="name" name="name" placeholder="Jane Doe" aria-label="Your Name" required />
+                                <div class="error-msg" id="err-name" aria-live="assertive"></div>
                                 </div>
                                 <div class="form-group">
                                     <label for="contact">Your Contact (Email or Phone)</label>
-                                    <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" required />
+                                    <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" aria-label="Your Contact" required />
                                     <div class="error-msg" id="err-contact" aria-live="assertive"></div>
                                 </div>
                                 <div class="form-group">
                                     <label for="question">Your Question</label>
-                                    <textarea id="question" name="question" placeholder="What would you like to know?" required></textarea>
+                                    <textarea id="question" name="question" placeholder="What would you like to know?" aria-label="Your Question" required></textarea>
                                     <div class="error-msg" id="err-question" aria-live="assertive"></div>
                                 </div>
                                 <div class="cta"><button type="submit">Submit</button></div>
@@ -572,17 +613,17 @@
                                     <input type="text" name="_gotcha" style="display:none">
                                     <div class="form-group">
                                         <label for="name">Your Name</label>
-                                        <input type="text" id="name" name="name" placeholder="Jane Doe" required />
+                                        <input type="text" id="name" name="name" placeholder="Jane Doe" aria-label="Your Name" required />
                                         <div class="error-msg" id="err-name" aria-live="assertive"></div>
                                     </div>
                                     <div class="form-group">
                                         <label for="contact">Your Contact (Email or Phone)</label>
-                                        <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" required />
+                                        <input type="text" id="contact" name="contact" placeholder="jane@example.com or +44 7700 900000" aria-label="Your Contact" required />
                                         <div class="error-msg" id="err-contact" aria-live="assertive"></div>
                                     </div>
                                     <div class="form-group">
                                         <label for="question">Your Question</label>
-                                        <textarea id="question" name="question" placeholder="What would you like to know?" required></textarea>
+                                        <textarea id="question" name="question" placeholder="What would you like to know?" aria-label="Your Question" required></textarea>
                                         <div class="error-msg" id="err-question" aria-live="assertive"></div>
                                     </div>
                                     <div class="cta"><button type="submit">Submit</button></div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - SereneAI LTD</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body{font-family:'Open Sans',sans-serif;background:#F6F9F9;color:#0B2342;margin:0;padding:2rem;line-height:1.7;}
+        h1{font-family:'Montserrat',sans-serif;color:#1D8A73;}
+        a{color:#1D8A73;}
+    </style>
+</head>
+<body>
+    <main>
+        <h1>Privacy Policy</h1>
+        <p>This privacy policy explains how SereneAI LTD ("we", "us") collects and uses your personal data in accordance with the UK General Data Protection Regulation (UK GDPR).</p>
+        <h2>Information We Collect</h2>
+        <p>We may collect basic contact details when you send us an enquiry. We only use this information to respond to your request.</p>
+        <h2>How We Use Your Data</h2>
+        <p>Your data is used solely to provide our services and to communicate with you. We do not sell or share your personal information with third parties for marketing purposes.</p>
+        <h2>Your Rights</h2>
+        <p>You have the right to access, correct or request deletion of your personal data. To exercise these rights, please contact us at <a href="mailto:info@sereneai.co.uk">info@sereneai.co.uk</a>.</p>
+        <h2>Cookies</h2>
+        <p>We use minimal cookies to improve your experience. By using this site you consent to our cookie policy.</p>
+        <h2>Contact</h2>
+        <p>If you have any questions about this policy, please email <a href="mailto:info@sereneai.co.uk">info@sereneai.co.uk</a>.</p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update hero copy to emphasise AI clarity for UK SMEs
- add call to action button in hero section
- include testimonials placeholder section
- create simple UK GDPR privacy page and link in footer/cookie banner
- add robots meta tag and organization JSON-LD
- add accessibility labels on nav links and form inputs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a8efb6928832a9441d24e36e3ec4b