### PR TITLE
Embed chatbot widget onto home page

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chatbot Widget - SereneAI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
+<style>
+:root{
+    --navy:#0B2342;
+    --teal:#1D8A73;
+    --light-gray:#F6F9F9;
+    --alt-light:#EEF5F4;
+    --dark-gray:#4D4D4D;
+    --white:#FFFFFF;
+}
+body{
+    margin:0;
+    font-family:'Open Sans',sans-serif;
+    background:var(--light-gray);
+    color:var(--navy);
+    line-height:1.7;
+    -webkit-font-smoothing:antialiased;
+}
+.container{
+    max-width:600px;
+    margin:2rem auto;
+    background:var(--white);
+    border-radius:12px;
+    box-shadow:0 4px 12px rgba(0,0,0,.05);
+    padding:1.5rem;
+}
+.chat-area{
+    min-height:300px;
+    display:flex;
+    flex-direction:column;
+    gap:1rem;
+}
+.message{
+    max-width:80%;
+    padding:.75rem 1rem;
+    border-radius:20px;
+    line-height:1.4;
+}
+.bot{
+    background:var(--alt-light);
+    align-self:flex-start;
+}
+.user{
+    background:var(--teal);
+    color:var(--white);
+    align-self:flex-end;
+}
+.input-area{
+    display:flex;
+    gap:.5rem;
+    margin-top:1rem;
+}
+.input-area input[type="text"]{
+    flex:1;
+    padding:.75rem 1rem;
+    border:1px solid #ccc;
+    border-radius:8px;
+    font-size:1rem;
+}
+.input-area button{
+    background:var(--teal);
+    color:var(--white);
+    border:none;
+    padding:.75rem 1.5rem;
+    border-radius:8px;
+    font-family:'Montserrat',sans-serif;
+    font-weight:600;
+    cursor:pointer;
+}
+.confirm-buttons{
+    display:flex;
+    gap:1rem;
+    margin-top:.5rem;
+}
+.confirm-buttons button{
+    padding:.5rem 1rem;
+    font-family:'Montserrat',sans-serif;
+    border-radius:8px;
+    border:none;
+    cursor:pointer;
+}
+.confirm-buttons .yes{background:var(--teal);color:var(--white);}
+.confirm-buttons .no{background:var(--navy);color:var(--white);}
+@media(max-width:480px){
+    .container{margin:1rem;}
+    .message{max-width:100%;}
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div id="chat" class="chat-area" aria-live="polite"></div>
+    <div id="input-area" class="input-area">
+        <input type="text" id="user-input" aria-label="Type your response">
+        <button id="send-btn">Send</button>
+    </div>
+    <div id="confirm-area"></div>
+    <div id="submit-area" style="display:none; margin-top:1rem;">
+        <button id="submit-btn">Submit</button>
+    </div>
+</div>
+<script>
+(function(){
+    const chat=document.getElementById('chat');
+    const userInput=document.getElementById('user-input');
+    const sendBtn=document.getElementById('send-btn');
+    const confirmArea=document.getElementById('confirm-area');
+    const submitArea=document.getElementById('submit-area');
+    const submitBtn=document.getElementById('submit-btn');
+
+    const data={};
+    let step=0;
+    let temp="";
+
+    function addMessage(text,cls){
+        const div=document.createElement('div');
+        div.className='message '+cls;
+        div.textContent=text;
+        chat.appendChild(div);
+        chat.scrollTop=chat.scrollHeight;
+    }
+
+    function ask(text){
+        addMessage(text,'bot');
+    }
+
+    function start(){
+        ask('Hello, I\'m the SereneAI assistant. May I have your full name, please?');
+    }
+
+    function handleSend(){
+        const value=userInput.value.trim();
+        if(!value)return;
+        addMessage(value,'user');
+        userInput.value='';
+        processInput(value);
+    }
+
+    function processInput(value){
+        switch(step){
+            case 0:
+                temp=value;
+                confirm(`You entered "${temp}". Is that correct?`,'name');
+                break;
+            case 2:
+                temp=value.toLowerCase();
+                confirm(`You prefer ${temp} as the contact method. Is that correct?`,'method');
+                break;
+            case 4:
+                temp=value;
+                confirm(`Is "${temp}" the correct contact detail?`,'detail');
+                break;
+            case 6:
+                temp=value;
+                confirm(`You said the reason is "${temp}". Is that correct?`,'reason');
+                break;
+            default:
+                break;
+        }
+    }
+
+    function confirm(text,type){
+        ask(text);
+        confirmArea.innerHTML='<div class="confirm-buttons"><button class="yes">Yes</button><button class="no">No</button></div>';
+        const yes=confirmArea.querySelector('.yes');
+        const no=confirmArea.querySelector('.no');
+        yes.onclick=()=>{
+            confirmArea.innerHTML='';
+            if(type==='name'){data.name=temp; step=1; ask('Thank you, '+data.name+'. Would you prefer email or phone for us to get in touch?'); step=2;}
+            else if(type==='method'){data.contactMethod=temp; step=3; ask('Please provide your '+data.contactMethod+'.'); step=4;}
+            else if(type==='detail'){data.contactDetail=temp; step=5; ask('What is the reason for contacting us? (general enquiry, support, booking, or feedback)'); step=6;}
+            else if(type==='reason'){data.reason=temp; step=7; finish();}
+        };
+        no.onclick=()=>{
+            confirmArea.innerHTML='';
+            if(type==='name'){step=0; ask('No problem. May I have your full name, please?');}
+            else if(type==='method'){step=2; ask('Okay, would you prefer email or phone?');}
+            else if(type==='detail'){step=4; ask('Please provide your '+data.contactMethod+'.');}
+            else if(type==='reason'){step=6; ask('Please tell me the reason for contacting us.');}
+        };
+    }
+
+    function finish(){
+        ask('All set. Please press Submit when you\'re ready.');
+        submitArea.style.display='block';
+    }
+
+    sendBtn.addEventListener('click',handleSend);
+    userInput.addEventListener('keypress',e=>{if(e.key==='Enter'){handleSend();}});
+
+    submitBtn.addEventListener('click',()=>{
+        submitArea.innerHTML='Thank you. Someone from our team will be in touch shortly.';
+        console.log('Chatbot data:',data);
+    });
+
+    start();
+})();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -426,6 +426,62 @@
     @media(max-width:680px){
         .mobile-cta{display:block;}
     }
+
+    /* ===== Chatbot Widget ===== */
+    .chatbot-container{
+        max-width:600px;
+        margin:2rem auto;
+        background:var(--white);
+        border-radius:12px;
+        box-shadow:0 4px 12px rgba(0,0,0,.05);
+        padding:1.5rem;
+    }
+    .chat-area{
+        min-height:300px;
+        display:flex;
+        flex-direction:column;
+        gap:1rem;
+    }
+    .message{
+        max-width:80%;
+        padding:.75rem 1rem;
+        border-radius:20px;
+        line-height:1.4;
+    }
+    .bot{background:var(--alt-light);align-self:flex-start;}
+    .user{background:var(--teal);color:var(--white);align-self:flex-end;}
+    .input-area{display:flex;gap:.5rem;margin-top:1rem;}
+    .input-area input[type="text"]{
+        flex:1;
+        padding:.75rem 1rem;
+        border:1px solid #ccc;
+        border-radius:8px;
+        font-size:1rem;
+    }
+    .input-area button{
+        background:var(--teal);
+        color:var(--white);
+        border:none;
+        padding:.75rem 1.5rem;
+        border-radius:8px;
+        font-family:'Montserrat',sans-serif;
+        font-weight:600;
+        cursor:pointer;
+    }
+    .confirm-buttons{display:flex;gap:1rem;margin-top:.5rem;}
+    .confirm-buttons button{
+        padding:.5rem 1rem;
+        font-family:'Montserrat',sans-serif;
+        border-radius:8px;
+        border:none;
+        cursor:pointer;
+    }
+    .confirm-buttons .yes{background:var(--teal);color:var(--white);}
+    .confirm-buttons .no{background:var(--navy);color:var(--white);}
+    @media(max-width:480px){
+        .chatbot-container{margin:1rem;}
+        .message{max-width:100%;}
+    }
 </style>
 </head>
 
@@ -517,6 +573,21 @@
                 </div>
                 <div class="cta"><button type="submit">Submit</button></div>
             </form>
+        </section>
+
+        <section id="chatbot" class="section" aria-labelledby="chatbot-heading">
+            <h2 id="chatbot-heading">Chat with Us</h2>
+            <div class="chatbot-container">
+                <div id="chat" class="chat-area" aria-live="polite"></div>
+                <div id="input-area" class="input-area">
+                    <input type="text" id="user-input" aria-label="Type your response" />
+                    <button id="send-btn">Send</button>
+                </div>
+                <div id="confirm-area"></div>
+                <div id="submit-area" style="display:none;margin-top:1rem;">
+                    <button id="submit-btn">Submit</button>
+                </div>
+            </div>
         </section>
     </main>
 
@@ -741,6 +812,100 @@
             setCookie(cookieName, cookieValue, cookieExpiryDays);
             cookieBanner.style.display = 'none';
         };
+    </script>
+
+    <script>
+    (function(){
+        const chat=document.getElementById('chat');
+        const userInput=document.getElementById('user-input');
+        const sendBtn=document.getElementById('send-btn');
+        const confirmArea=document.getElementById('confirm-area');
+        const submitArea=document.getElementById('submit-area');
+        const submitBtn=document.getElementById('submit-btn');
+
+        if(!chat) return;
+
+        const data={};
+        let step=0;
+        let temp="";
+
+        function addMessage(text,cls){
+            const div=document.createElement('div');
+            div.className='message '+cls;
+            div.textContent=text;
+            chat.appendChild(div);
+            chat.scrollTop=chat.scrollHeight;
+        }
+
+        function ask(text){addMessage(text,'bot');}
+
+        function start(){ask("Hello, I'm the SereneAI assistant. May I have your full name, please?");}
+
+        function handleSend(){
+            const value=userInput.value.trim();
+            if(!value)return;
+            addMessage(value,'user');
+            userInput.value='';
+            processInput(value);
+        }
+
+        function processInput(value){
+            switch(step){
+                case 0:
+                    temp=value;
+                    confirmStep(`You entered "${temp}". Is that correct?`,'name');
+                    break;
+                case 2:
+                    temp=value.toLowerCase();
+                    confirmStep(`You prefer ${temp} as the contact method. Is that correct?`,'method');
+                    break;
+                case 4:
+                    temp=value;
+                    confirmStep(`Is "${temp}" the correct contact detail?`,'detail');
+                    break;
+                case 6:
+                    temp=value;
+                    confirmStep(`You said the reason is "${temp}". Is that correct?`,'reason');
+                    break;
+            }
+        }
+
+        function confirmStep(text,type){
+            ask(text);
+            confirmArea.innerHTML='<div class="confirm-buttons"><button class="yes">Yes</button><button class="no">No</button></div>';
+            const yes=confirmArea.querySelector('.yes');
+            const no=confirmArea.querySelector('.no');
+            yes.onclick=()=>{
+                confirmArea.innerHTML='';
+                if(type==='name'){data.name=temp; step=1; ask('Thank you, '+data.name+'. Would you prefer email or phone for us to get in touch?'); step=2;}
+                else if(type==='method'){data.contactMethod=temp; step=3; ask('Please provide your '+data.contactMethod+'.'); step=4;}
+                else if(type==='detail'){data.contactDetail=temp; step=5; ask('What is the reason for contacting us? (general enquiry, support, booking, or feedback)'); step=6;}
+                else if(type==='reason'){data.reason=temp; step=7; finish();}
+            };
+            no.onclick=()=>{
+                confirmArea.innerHTML='';
+                if(type==='name'){step=0; ask('No problem. May I have your full name, please?');}
+                else if(type==='method'){step=2; ask('Okay, would you prefer email or phone?');}
+                else if(type==='detail'){step=4; ask('Please provide your '+data.contactMethod+'.');}
+                else if(type==='reason'){step=6; ask('Please tell me the reason for contacting us.');}
+            };
+        }
+
+        function finish(){
+            ask('All set. Please press Submit when you\'re ready.');
+            submitArea.style.display='block';
+        }
+
+        sendBtn.addEventListener('click',handleSend);
+        userInput.addEventListener('keypress',e=>{if(e.key==='Enter'){handleSend();}});
+
+        submitBtn.addEventListener('click',()=>{
+            submitArea.innerHTML='Thank you. Someone from our team will be in touch shortly.';
+            console.log('Chatbot data:',data);
+        });
+
+        start();
+    })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed chatbot section directly into `index.html`
- add widget styles and inline script for conversational flow
- keep contact form and cookie banner working

## Testing
- `tidy -e index.html`
- `tidy -e chatbot.html`

------
https://chatgpt.com/codex/tasks/task_e_686ae0108214832a960750ec3abadae2