### PR TITLE
Add site-wide contact modal

### DIFF
--- a/gpts.html
+++ b/gpts.html
@@ -52,6 +52,23 @@
         </p>
         <button id="accept-cookies">Accept</button>
     </div>
+
+    <button id="cta-button" class="cta-button">Get Started</button>
+    <div id="cta-modal" class="cta-modal" role="dialog" aria-modal="true" aria-labelledby="cta-heading">
+        <div class="modal-content">
+            <button id="cta-close" aria-label="Close modal">&times;</button>
+            <h2 id="cta-heading">Let’s talk – share your details and we’ll be in touch</h2>
+            <form id="cta-form">
+                <label for="cta-name">Name</label>
+                <input id="cta-name" name="name" type="text" required>
+                <label for="cta-email">Email</label>
+                <input id="cta-email" name="email" type="email" required>
+                <label for="cta-company">Company</label>
+                <input id="cta-company" name="company" type="text">
+                <button type="submit">Submit</button>
+            </form>
+        </div>
+    </div>
     <script src="script.js"></script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,23 @@
         </p>
         <button id="accept-cookies">Accept</button>
     </div>
+
+    <button id="cta-button" class="cta-button">Get Started</button>
+    <div id="cta-modal" class="cta-modal" role="dialog" aria-modal="true" aria-labelledby="cta-heading">
+        <div class="modal-content">
+            <button id="cta-close" aria-label="Close modal">&times;</button>
+            <h2 id="cta-heading">Let’s talk – share your details and we’ll be in touch</h2>
+            <form id="cta-form">
+                <label for="cta-name">Name</label>
+                <input id="cta-name" name="name" type="text" required>
+                <label for="cta-email">Email</label>
+                <input id="cta-email" name="email" type="email" required>
+                <label for="cta-company">Company</label>
+                <input id="cta-company" name="company" type="text">
+                <button type="submit">Submit</button>
+            </form>
+        </div>
+    </div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -24,5 +24,23 @@
         <h2>Cookies</h2>
         <p>We use minimal cookies to improve your experience. By using this site you consent to our cookie policy.</p>
     </main>
+
+    <button id="cta-button" class="cta-button">Get Started</button>
+    <div id="cta-modal" class="cta-modal" role="dialog" aria-modal="true" aria-labelledby="cta-heading">
+        <div class="modal-content">
+            <button id="cta-close" aria-label="Close modal">&times;</button>
+            <h2 id="cta-heading">Let’s talk – share your details and we’ll be in touch</h2>
+            <form id="cta-form">
+                <label for="cta-name">Name</label>
+                <input id="cta-name" name="name" type="text" required>
+                <label for="cta-email">Email</label>
+                <input id="cta-email" name="email" type="email" required>
+                <label for="cta-company">Company</label>
+                <input id="cta-company" name="company" type="text">
+                <button type="submit">Submit</button>
+            </form>
+        </div>
+    </div>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -37,4 +37,48 @@ document.addEventListener('DOMContentLoaded', function() {
       cookieBanner.style.display = 'none';
     });
   }
+
+  const ctaButton = document.getElementById('cta-button');
+  const ctaModal = document.getElementById('cta-modal');
+  const ctaClose = document.getElementById('cta-close');
+  const ctaForm = document.getElementById('cta-form');
+
+  function closeModal() {
+    if (ctaModal) {
+      ctaModal.style.display = 'none';
+      document.body.style.overflow = '';
+    }
+  }
+
+  if (ctaButton && ctaModal) {
+    ctaButton.addEventListener('click', function() {
+      ctaModal.style.display = 'flex';
+      document.body.style.overflow = 'hidden';
+      const firstInput = document.getElementById('cta-name');
+      if (firstInput) firstInput.focus();
+    });
+
+    if (ctaClose) {
+      ctaClose.addEventListener('click', closeModal);
+    }
+
+    ctaModal.addEventListener('click', function(e) {
+      if (e.target === ctaModal) {
+        closeModal();
+      }
+    });
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    });
+
+    if (ctaForm) {
+      ctaForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        ctaForm.innerHTML = '<p>Thank you. We\'ll be in touch soon.</p>';
+      });
+    }
+  }
 });

--- a/style.css
+++ b/style.css
@@ -260,4 +260,96 @@
         transform: translateY(-2px); /* Subtle hover effect */
     }
 
+    /* === CTA Button === */
+    #cta-button {
+        position: fixed;
+        bottom: 1.5rem;
+        right: 1.5rem;
+        background-color: var(--teal);
+        color: #fff;
+        border: none;
+        padding: 0.9rem 1.75rem;
+        border-radius: 3rem;
+        font-size: 1.1rem;
+        cursor: pointer;
+        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+        z-index: 900;
+        transition: background-color 0.3s ease, transform 0.2s ease-in-out;
+    }
+
+    #cta-button:hover {
+        background-color: #16725D;
+        transform: translateY(-2px);
+    }
+
+    /* === Modal === */
+    #cta-modal {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.5);
+        align-items: center;
+        justify-content: center;
+        z-index: 1001;
+        padding: 1rem;
+    }
+
+    #cta-modal .modal-content {
+        background-color: var(--white);
+        color: var(--navy);
+        border-radius: 8px;
+        max-width: 420px;
+        width: 100%;
+        padding: 2rem;
+        box-shadow: 0 6px 10px rgba(0,0,0,0.1);
+        text-align: center;
+    }
+
+    #cta-modal label {
+        display: block;
+        margin-top: 1rem;
+        text-align: left;
+    }
+
+    #cta-modal input {
+        width: 100%;
+        padding: 0.5rem;
+        margin-top: 0.25rem;
+        border: 1px solid var(--dark-gray);
+        border-radius: 4px;
+        font-size: 1rem;
+    }
+
+    #cta-modal button[type="submit"] {
+        background-color: var(--teal);
+        color: #fff;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 1rem;
+        margin-top: 1.25rem;
+        transition: background-color 0.3s ease, transform 0.2s ease-in-out;
+    }
+
+    #cta-modal button[type="submit"]:hover {
+        background-color: #16725D;
+        transform: translateY(-2px);
+    }
+
+    #cta-close {
+        background: none;
+        border: none;
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        font-size: 1.2rem;
+        cursor: pointer;
+        color: var(--dark-gray);
+    }
+
+
 


### PR DESCRIPTION
## Summary
- add a fixed CTA button with modal form on all pages
- style button and modal in CSS
- handle modal open/close and form submission in JavaScript

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afded5ce0832a82eea976ee54e9fa