### PR TITLE
Add WebContainer GPT hero

### DIFF
--- a/gpts.html
+++ b/gpts.html
@@ -35,11 +35,19 @@
             <p>Helpful tools designed to support your productivity, automation, and creative workflows.</p>
         </section>
 
+        <section class="hero gpt-hero">
+            <h2>WebContainer – Your UK-Based Browser Coding Tool</h2>
+            <a href="https://chatgpt.com/g/g-686c3b90f5dc8191a0a4ddf68a13acf7-webcontainer-your-uk-based-browser-coding-tool"
+               class="primary-cta" target="_blank" rel="noopener noreferrer"
+               aria-label="Launch WebContainer GPT in ChatGPT">
+                Launch GPT
+            </a>
+        </section>
+
         <section class="section">
             <div class="icons-row">
                 <div class="icon-card">
                     <h3>UK Co-Creator for Better AI Outputs</h3>
-                    <p>UK Helps you craft, fix, and optimise prompts across ChatGPT, Claude, Gemini, and more. Tailored for UK users, it simplifies prompt engineering for content, chatbots, automation, and research—no jargon, just smarter AI results.</p>
                     <a class="primary-cta" href="https://chatgpt.com/g/g-6869aaddbec48191812a111533a36363-promptpilot-uk-co-creator-for-better-ai-outputs" target="_blank" rel="noopener noreferrer">Try it</a>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -124,7 +124,7 @@
         animation:fadeInDown 1s ease-in-out;
         color: var(--navy); /* Ensure text color */
     }
-    .hero p{
+.hero p{
         font-size:1.5rem; /* Slightly larger paragraph */
         color:var(--dark-gray);
         max-width:800px; /* Wider max width */
@@ -159,6 +159,17 @@
     gap:2.5rem; /* Increased gap */
     justify-items:center;
     margin-top:3rem; /* Increased margin */
+}
+
+/* ===== GPT Hero ===== */
+.gpt-hero h2{
+    font-family:'Montserrat',sans-serif;
+    font-size:2.5rem;
+    margin:0 0 1.5rem;
+    color:var(--navy);
+}
+.gpt-hero .primary-cta{
+    margin-top:1rem;
 }
 
 /* Services carousel */


### PR DESCRIPTION
## Summary
- feature new hero section for WebContainer GPT
- simplify first GPT card and keep only the link
- style the new hero heading and link

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686d87579fe4832aba57f28b42f34599