### PR TITLE
Add Supabase auth pages

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,6 @@
+// Shared Supabase client initialization
+const SUPABASE_URL = 'https://zzddwdnnddgfjtcncygj.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6ZGR3ZG5uZGRnZmp0Y25jeWdqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIwMTIwNDYsImV4cCI6MjA2NzU4ODA0Nn0.ElGic4KR5p9XlRAt3QLlsxeMYlwksXcRLKqhm-uVs8U';
+
+// `supabase` becomes a global variable that other scripts can use
+const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/gpts.html
+++ b/gpts.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https:; connect-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https:; connect-src 'self' https://zzddwdnnddgfjtcncygj.supabase.co">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <title>SereneAI GPTs</title>
     <meta name="description" content="Free GPT tools from SereneAI" />
@@ -14,7 +14,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="style.css">
-    
+
+    <!-- Supabase client -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <script src="auth.js"></script>
+
 </head>
 <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -26,6 +30,7 @@
             <a href="index.html" aria-label="Home">Home</a>
             <a href="gpts.html" aria-label="SereneAI GPTs">GPTs</a>
             <a href="products.html" aria-label="Products page">Products</a>
+            <a href="#" id="logout-button" aria-label="Logout">Logout</a>
         </nav>
     </header>
 
@@ -97,6 +102,25 @@
         </div>
     </div>
     <script src="script.js" defer></script>
+    <script>
+    // Ensure user is authenticated before showing content
+    document.addEventListener('DOMContentLoaded', async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) {
+            window.location.replace('login.html');
+            return;
+        }
+
+        const logoutBtn = document.getElementById('logout-button');
+        if (logoutBtn) {
+            logoutBtn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                await supabase.auth.signOut();
+                window.location.replace('login.html');
+            });
+        }
+    });
+    </script>
 
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https:; connect-src 'self' https://zzddwdnnddgfjtcncygj.supabase.co">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <title>Login - SereneAI</title>
+    <link rel="alternate" href="https://sereneai.co.uk/login.html" hreflang="en-GB">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <script src="auth.js"></script>
+</head>
+<body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <header role="banner">
+        <div class="logo">SereneAI&nbsp;LTD</div>
+        <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation">
+        <label for="nav-toggle" class="nav-label"><span></span></label>
+        <nav aria-label="Main navigation">
+            <a href="index.html" aria-label="Home">Home</a>
+            <a href="gpts.html" aria-label="SereneAI GPTs">GPTs</a>
+            <a href="products.html" aria-label="Products page">Products</a>
+        </nav>
+    </header>
+    <main id="main-content">
+        <section class="hero">
+            <h1>Login</h1>
+            <form id="login-form" class="auth-form">
+                <label for="login-email">Email</label>
+                <input id="login-email" type="email" required>
+                <label for="login-password">Password</label>
+                <input id="login-password" type="password" required>
+                <button type="submit">Login</button>
+            </form>
+            <p>Need an account? <a href="signup.html">Sign up</a></p>
+        </section>
+    </main>
+    <footer role="contentinfo">
+        <p>&copy; <span id="current-year">2024</span> SereneAI LTD. All rights reserved. <a href="privacy.html">Privacy Policy</a></p>
+    </footer>
+    <script src="script.js" defer></script>
+    <script>
+    // Handle login form submission using Supabase
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('login-email').value;
+        const password = document.getElementById('login-password').value;
+        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) {
+            alert(error.message);
+        } else {
+            window.location.href = 'gpts.html';
+        }
+    });
+    </script>
+</body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https:; connect-src 'self' https://zzddwdnnddgfjtcncygj.supabase.co">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
+    <title>Sign Up - SereneAI</title>
+    <link rel="alternate" href="https://sereneai.co.uk/signup.html" hreflang="en-GB">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <script src="auth.js"></script>
+</head>
+<body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <header role="banner">
+        <div class="logo">SereneAI&nbsp;LTD</div>
+        <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation">
+        <label for="nav-toggle" class="nav-label"><span></span></label>
+        <nav aria-label="Main navigation">
+            <a href="index.html" aria-label="Home">Home</a>
+            <a href="gpts.html" aria-label="SereneAI GPTs">GPTs</a>
+            <a href="products.html" aria-label="Products page">Products</a>
+        </nav>
+    </header>
+    <main id="main-content">
+        <section class="hero">
+            <h1>Sign Up</h1>
+            <form id="signup-form" class="auth-form">
+                <label for="signup-email">Email</label>
+                <input id="signup-email" type="email" required>
+                <label for="signup-password">Password</label>
+                <input id="signup-password" type="password" required>
+                <button type="submit">Sign Up</button>
+            </form>
+            <p>Already have an account? <a href="login.html">Login</a></p>
+        </section>
+    </main>
+    <footer role="contentinfo">
+        <p>&copy; <span id="current-year">2024</span> SereneAI LTD. All rights reserved. <a href="privacy.html">Privacy Policy</a></p>
+    </footer>
+    <script src="script.js" defer></script>
+    <script>
+    // Handle sign-up form submission using Supabase
+    document.getElementById('signup-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('signup-email').value;
+        const password = document.getElementById('signup-password').value;
+        const { error } = await supabase.auth.signUp({ email, password });
+        if (error) {
+            alert(error.message);
+        } else {
+            window.location.href = 'gpts.html';
+        }
+    });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -534,3 +534,41 @@ body.intro-playing #cta-modal {
     #logo-intro .logo { color: var(--white); }
 }
 
+/* ===== Auth Forms ===== */
+.auth-form {
+    max-width: 400px;
+    margin: 2rem auto 0;
+    text-align: left;
+}
+
+.auth-form label {
+    display: block;
+    margin-top: 1rem;
+}
+
+.auth-form input {
+    width: 100%;
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+    border: 1px solid var(--dark-gray);
+    border-radius: 4px;
+    font-size: 1rem;
+}
+
+.auth-form button {
+    background-color: var(--teal);
+    color: #fff;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+    margin-top: 1.25rem;
+    transition: background-color 0.3s ease, transform 0.2s ease-in-out;
+}
+
+.auth-form button:hover {
+    background-color: #16725D;
+    transform: translateY(-2px);
+}
+


### PR DESCRIPTION
## Summary
- create login and signup pages using Supabase auth
- add shared `auth.js` for Supabase client initialization
- enforce authentication on `gpts.html` and add logout link
- style forms with new `.auth-form` class

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d9bf59238832a8ac7953590b7e7ea